### PR TITLE
Ajfaust patch

### DIFF
--- a/Project3/ProblemA.R
+++ b/Project3/ProblemA.R
@@ -108,11 +108,10 @@ secretdecoder <- function(imgfilename,startpix,stride,consec=NULL){
   pixel <- startpix
   # Vector to hold all read characters
   message <- intToUtf8(round(pa[startpix]*128))
+  # Avoids index being 0
+  pixel <- modifyindex(pixel+stride,pa)
 
   if(is.null(consec)){
-    pixel <- pixel + stride
-    # Avoids index being 0
-    pixel <- modifyindex(pixel,pa)
     count <- 0
     # Read every 'stride'th pixel, and add it's corresponding utf value to message
     #   until null character is reached (rounding is needed as division is not
@@ -127,7 +126,6 @@ secretdecoder <- function(imgfilename,startpix,stride,consec=NULL){
   else{
     # Vector containing all positions that have been read
     check <- startpix
-    pixel <- modifyindex(pixel+stride,pa)
     count <- 0
     # Loop until null character is encountered
     while(pa[pixel] != 0){


### PR DESCRIPTION
Modified the code to account for wrapping around once the end of the image is reached. The check for relative primeness is probably not correct, but I wanted to get these changes out ASAP. 

The modifyindex function may be a bit confusing. All it does is mods the current index with the length of the image (to wrap around if needed). If the result is 0, then the index will be the last one in the image.

For consecutive pixels, there is a vector called "check" that contains all positions that have been written to/read from so far. Whenever we want to check for consecutive pixels, we see if the positions of the surrounding pixels are in the check vector. If more than consec positions are in the check vector, then move to the next pixel. Otherwise, write to the current pixel. This is necessary as a check for consecutive pixels is needed for the decoder.

Please let me know if you are confused about any of this ASAP. I know it's a lot of changes, so I will try my best to explain what is going on.